### PR TITLE
Add a --transparent option which render output on a transparent background.

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -276,7 +276,7 @@ examples:
         return
     if options.filename:
         if len(args) != 1 or args[0] == "-":
-          print "--filename option requires exactly one url"
+          self.error("--filename option requires exactly one url")
           return
     if options.scale == 0:
       cmdparser.error("scale cannot be zero")


### PR DESCRIPTION
This pull request add a new `--transparent` (aliased to `-t`) option which render the output on a transparent background.
To make sure it works, be sure to have a transparent background defined in the document stylesheet.

```
html, body {
    background: transparent;
}
```
