### PR TITLE
fix crashing on timeout

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -48,8 +48,8 @@ class AppDelegate (Foundation.NSObject):
         self.performSelector_withObject_afterDelay_( "timeout:", None, 60 )
 
     def timeout_(self, obj):
-        NSLog("timed out!")
-        NSApplication.sharedApplication().terminate_(None)
+        Foundation.NSLog("timed out!")
+        AppKit.NSApplication.sharedApplication().terminate_(None)
 
 class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
 


### PR DESCRIPTION
This patch fixes this error occurring when the web request times out:

```
2011-11-30 10:45:35.982 Python[33249:d07] <type 'exceptions.NameError'>: global name 'NSLog' is not defined
```
