### PR TITLE
Change minimum width and height to 0

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -314,7 +314,7 @@ Examples:
     if options.height>0.0:
        options.initHeight = options.height
     else:
-       print "Width must be greater than zero"
+       print "Height must be greater than zero"
        return
       
     app = AppKit.NSApplication.sharedApplication()


### PR DESCRIPTION
Hi Paul,

Like everyone before me, I first want to thank you for an amazing program. Huge help.
I've changed the option parsing code to set the width and height to any value greater than 0, but keep the default of 800x600. I needed this feature to test responsive CSS, and I think it might help out some other cats too.

If there is some hard minimum that the WebView shouldn't go below, please let me know. I've tested it down to `-W 300` and gotten the desired results.

Again, thanks for the awesome work,
Perkee
