### PR TITLE
Add --cookies option to pass in a cookie file

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -226,7 +226,7 @@ class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
             cookie = ''
             if self.options.cookieFile:
                 try:
-                    cookie = cookieFromFile(self.options.cookieFile, nsurl)
+                    cookie = cookieFromFile(self.options.cookieFile, str(nsurl))
                 except:
                     print "cookie loading error: ", sys.exc_info()
                     AppKit.NSApplication.sharedApplication().terminate_(None)

--- a/webkit2png
+++ b/webkit2png
@@ -202,6 +202,9 @@ class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
 
             req.setValue_forHTTPHeaderField_(cookie, 'Cookie')
 
+        if self.options.no_cookies:
+            req.setValue_forHTTPHeaderField_('', 'Cookie')
+
         webview.mainFrame().loadRequest_(req)
 
         if not webview.mainFrame().provisionalDataSource():
@@ -442,6 +445,10 @@ Examples:
         "--cookie", action="append", type="string", dest="cookieData",
         help="specify a cookie name-value pair (multiple --cookie is allowed)",
         metavar="NAME=VALUE")
+    group.add_option(
+        "--no-cookies", action="store_true",
+        help="explicitly empty the Cookie: header (Safari's cookies are used by default)")
+
     cmdparser.add_option_group(group)
 
     (options, args) = cmdparser.parse_args()

--- a/webkit2png
+++ b/webkit2png
@@ -196,13 +196,21 @@ class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
         scriptobject.setValue_forKey_(Webkit2PngScriptBridge.alloc().init(), 'webkit2png')
 
         req = Foundation.NSMutableURLRequest.requestWithURL_(Foundation.NSURL.URLWithString_(url))
-        if (self.options.cookieFile):
-            try:
-                cookie = cookieFromFile(self.options.cookieFile, url)
-                req.setValue_forHTTPHeaderField_(cookie, 'Cookie')
-            except:
-                print "cookie loading error: ", sys.exc_info()
-                AppKit.NSApplication.sharedApplication().terminate_(None)
+
+        if self.options.cookieFile or self.options.cookieData:
+            cookie = ''
+            if self.options.cookieFile:
+                try:
+                    cookie = cookieFromFile(self.options.cookieFile, url)
+                except:
+                    print "cookie loading error: ", sys.exc_info()
+                    AppKit.NSApplication.sharedApplication().terminate_(None)
+            if self.options.cookieData:
+                if cookie:
+                    cookie += '; '
+                cookie += '; '.join(self.options.cookieData)
+
+            req.setValue_forHTTPHeaderField_(cookie, 'Cookie')
 
         webview.mainFrame().loadRequest_(req)
 
@@ -362,8 +370,10 @@ Examples:
        help=optparse.SUPPRESS_HELP)
     group.add_option("--no-js", action="store_true",
        help="disable JavaScript support")
-    group.add_option("--cookies", type="string", metavar="FILENAME", dest="cookieFile",
+    group.add_option("--cookie-file", type="string", metavar="FILENAME", dest="cookieFile",
        help="specify a Netscape cookie file")
+    group.add_option("--cookie", type="string", metavar="NAME=VALUE", dest="cookieData", action="append",
+       help="specify a cookie name-value pair (multiple --cookie is allowed)")
     group.add_option("--transparent", action="store_true",
        help="render output on a transparent background (requires a web page with a transparent background)", default=False)
     cmdparser.add_option_group(group)

--- a/webkit2png
+++ b/webkit2png
@@ -469,10 +469,14 @@ Examples:
         "--transparent", action="store_true",
         help="render output on a transparent background (requires a web "
         "page with a transparent background)", default=False)
-    group.add_option("--cookie-file", type="string", metavar="FILENAME", dest="cookieFile",
-       help="specify a Netscape cookie file")
-    group.add_option("--cookie", type="string", metavar="NAME=VALUE", dest="cookieData", action="append",
-       help="specify a cookie name-value pair (multiple --cookie is allowed)")
+    group.add_option(
+        "--cookie-file", type="string", dest="cookieFile",
+        help="specify a Netscape cookie file",
+        metavar="FILENAME")
+    group.add_option(
+        "--cookie", action="append", type="string", dest="cookieData",
+        help="specify a cookie name-value pair (multiple --cookie is allowed)",
+        metavar="NAME=VALUE")
     cmdparser.add_option_group(group)
 
     (options, args) = cmdparser.parse_args()

--- a/webkit2png
+++ b/webkit2png
@@ -41,41 +41,6 @@ except ImportError:
     print "Cannot find pyobjc library files.  Are you sure it is installed?"
     sys.exit()
 
-# given a cookie filename and a url, return the value for an HTTP cookie
-# header
-def cookieFromFile(filename, url):
-    import cookielib
-    import urllib2
-    import tempfile
-    import os
-
-    # cookielib won't even look at the rest of a cookie file if the first line
-    # doesn't match a particular regex, so we always guarantee the magic_re
-    # will succeed
-    tmp = tempfile.NamedTemporaryFile(delete=False)
-    tmp.write("# Netscape HTTP Cookie File\n")
-    real = open(filename, "r")
-    while 1:
-        line = real.readline()
-        if line:
-            tmp.write(line)
-        else:
-            break
-    tmp.close()
-
-    # we only need this Request() long enough to have cookielib set the Cookie
-    # header for us, we never actually pass it urlopen() or the like
-    req = urllib2.Request(url)
-    jar = cookielib.MozillaCookieJar(tmp.name)
-    jar.load()
-    jar.add_cookie_header(req)
-
-    cookie = req.get_header("Cookie")
-    if not cookie:
-        cookie = ""
-
-    os.unlink(tmp.name)
-    return cookie
 
 class AppDelegate(Foundation.NSObject):
     # what happens when the app starts up
@@ -562,6 +527,42 @@ Examples:
     webview.setFrameLoadDelegate_(loaddelegate)
 
     app.run()
+
+# given a cookie filename and a url, return the value for an HTTP cookie
+# header
+def cookieFromFile(filename, url):
+    import cookielib
+    import urllib2
+    import tempfile
+    import os
+
+    # cookielib won't even look at the rest of a cookie file if the first line
+    # doesn't match a particular regex, so we always guarantee the magic_re
+    # will succeed
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.write("# Netscape HTTP Cookie File\n")
+    real = open(filename, "r")
+    while 1:
+        line = real.readline()
+        if line:
+            tmp.write(line)
+        else:
+            break
+    tmp.close()
+
+    # we only need this Request() long enough to have cookielib set the Cookie
+    # header for us, we never actually pass it urlopen() or the like
+    req = urllib2.Request(url)
+    jar = cookielib.MozillaCookieJar(tmp.name)
+    jar.load()
+    jar.add_cookie_header(req)
+
+    cookie = req.get_header("Cookie")
+    if not cookie:
+        cookie = ""
+
+    os.unlink(tmp.name)
+    return cookie
 
 if __name__ == '__main__':
     main()

--- a/webkit2png
+++ b/webkit2png
@@ -38,6 +38,42 @@ except ImportError:
   print "Cannot find pyobjc library files.  Are you sure it is installed?"
   sys.exit()
 
+# given a cookie filename and a url, return the value for an HTTP cookie
+# header
+def cookieFromFile(filename, url):
+    import cookielib
+    import urllib2
+    import tempfile
+    import os
+
+    # cookielib won't even look at the rest of a cookie file if the first line
+    # doesn't match a particular regex, so we always guarantee the magic_re
+    # will succeed
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.write("# Netscape HTTP Cookie File\n")
+    real = open(filename, "r")
+    while 1:
+        line = real.readline()
+        if line:
+            tmp.write(line)
+        else:
+            break
+    tmp.close()
+
+    # we only need this Request() long enough to have cookielib set the Cookie
+    # header for us, we never actually pass it urlopen() or the like
+    req = urllib2.Request(url)
+    jar = cookielib.MozillaCookieJar(tmp.name)
+    jar.load()
+    jar.add_cookie_header(req)
+
+    cookie = req.get_header("Cookie")
+    if not cookie:
+        cookie = ""
+
+    os.unlink(tmp.name)
+    return cookie
+
 class AppDelegate (Foundation.NSObject):
     # what happens when the app starts up
     def applicationDidFinishLaunching_(self, aNotification):
@@ -159,7 +195,17 @@ class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
         scriptobject = webview.windowScriptObject()
         scriptobject.setValue_forKey_(Webkit2PngScriptBridge.alloc().init(), 'webkit2png')
 
-        webview.mainFrame().loadRequest_(Foundation.NSURLRequest.requestWithURL_(Foundation.NSURL.URLWithString_(url)))
+        req = Foundation.NSMutableURLRequest.requestWithURL_(Foundation.NSURL.URLWithString_(url))
+        if (self.options.cookieFile):
+            try:
+                cookie = cookieFromFile(self.options.cookieFile, url)
+                req.setValue_forHTTPHeaderField_(cookie, 'Cookie')
+            except:
+                print "cookie loading error: ", sys.exc_info()
+                AppKit.NSApplication.sharedApplication().terminate_(None)
+
+        webview.mainFrame().loadRequest_(req)
+
         if not webview.mainFrame().provisionalDataSource():
             print " ... not a proper url?"
             self.getURL(webview)
@@ -316,6 +362,8 @@ Examples:
        help=optparse.SUPPRESS_HELP)
     group.add_option("--no-js", action="store_true",
        help="disable JavaScript support")
+    group.add_option("--cookies", type="string", metavar="FILENAME", dest="cookieFile",
+       help="specify a Netscape cookie file")
     group.add_option("--transparent", action="store_true",
        help="render output on a transparent background (requires a web page with a transparent background)", default=False)
     cmdparser.add_option_group(group)


### PR DESCRIPTION
_This is a re-pullrequest of #31, but against the most recent master (since I'm a bit more up to speed with git now)_

Use a browser extension such as:

https://chrome.google.com/webstore/detail/cookietxt-export/lopabhfecdfhgogdbojmaicoicjekelh

...to dump cookies into a file, and then pass in the filename with
"--cookies FILENAME". You can also copy the cookie file content, and
then do "--cookies <(pbpaste)" to skip the intermediate file.
