### PR TITLE
remove the http(s) proto before removing non-word characters

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -96,8 +96,8 @@ class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
          filename = md5.new(URL).hexdigest()
        else:
          import re
-         filename = re.sub('\W','',URL);
-         filename = re.sub('^https?','',filename);
+         filename = re.sub('^https?','',URL);
+         filename = re.sub('\W','',filename);
        if options.datestamp:
          import time
          now = time.strftime("%Y%m%d")


### PR DESCRIPTION
Domains that start with "s" get chopped because the regexes were in the wrong order.
For example "http://seancoates.com/" became "eancoates.com" because:
- `http://seancoates.com`
- (remove non-word chars)
- `httpseancoatescom`
- (remove proto/prefix)
- `eancoatescom`
