### PR TITLE
Added logic to auto-scale when output width is smaller than the scaled clipwidth

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -433,6 +433,11 @@ Examples:
         options.clipped = True
     # work out the initial size of the browser window
     #  (this might need to be larger so clipped image is right size)
+
+    if options.width*options.zoom < options.clipwidth/options.scale:
+        # auto adjust scale to produce clipwidth
+        options.scale = options.clipwidth / (options.width * options.zoom)
+
     options.initWidth = (options.clipwidth / options.scale)
     options.initHeight = (options.clipheight / options.scale)
     options.width *= options.zoom


### PR DESCRIPTION
Addresses issue #12 — Specifying a small canvas size doesn't work.

Simply calculates scale parameter from width.
