### PR TITLE
Adds option to ignore SSL certificate errors and SSL-Hostname mismatches

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -174,6 +174,10 @@ class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
                 nsurl = Foundation.NSURL.alloc().initFileURLWithPath_(url)
         nsurl = nsurl.absoluteURL()
 
+        #disable certificate checking
+        if self.options.ignore_ssl_check:
+            Foundation.NSURLRequest.setAllowsAnyHTTPSCertificate_forHost_(objc.YES, nsurl.host())
+
         print "Fetching", nsurl, "..."
         self.resetWebview(webview)
         scriptobject = webview.windowScriptObject()
@@ -410,6 +414,9 @@ Examples:
         "--transparent", action="store_true",
         help="render output on a transparent background (requires a web "
         "page with a transparent background)", default=False)
+    group.add_option(
+        "--ignore-ssl-check", action="store_true",
+        help="ignore SSL Certificate name mismatches", default=False)
     cmdparser.add_option_group(group)
 
     (options, args) = cmdparser.parse_args()


### PR DESCRIPTION
Some of the sites in my organization's dev environment are using SSL certs that don't match the hostname. This caused a fatal error in webkit2png. This adds an option to ignore the ssl error. 
