### PR TITLE
Fix cropping on retina displays

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -283,9 +283,9 @@ class WebkitLoad (Foundation.NSObject, WebKit.protocols.WebFrameLoadDelegate):
 
             zoom = self.options.zoom
 
-            cropRect = Foundation.NSMakeRect(
+            cropRect = view.window().convertRectToBacking_(Foundation.NSMakeRect(
                 zoom * left, zoom * top,
-                zoom * el.offsetWidth(), zoom * el.offsetHeight())
+                zoom * el.offsetWidth(), zoom * el.offsetHeight()))
 
             cropped = Quartz.CGImageCreateWithImageInRect(
                 bitmapdata.CGImage(), cropRect)


### PR DESCRIPTION
Converts the crop rect to backing store coordinates, so it works properly when the main display is a retina display. Thanks @paulhammond for pointing in the right direction!

Fixes #64
