### PR TITLE
Allows for use of non-https domains under El Capitan

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -419,6 +419,10 @@ Examples:
     # Hide the dock icon (needs to run before NSApplication.sharedApplication)
     AppKit.NSBundle.mainBundle().infoDictionary()['LSBackgroundOnly'] = '1'
 
+    # Handles ATS HTTPS requirement introduced in El Cap
+    if options.ignore_ssl_check:
+        AppKit.NSBundle.mainBundle().infoDictionary()['NSAppTransportSecurity'] = dict(NSAllowsArbitraryLoads = True)
+
     app = AppKit.NSApplication.sharedApplication()
 
     # create an app delegate


### PR DESCRIPTION
... when --ignore-ssl-check is enabled

Fixes #90
