### PR TITLE
Allow loading of HTTP pages

### DIFF
--- a/webkit2png
+++ b/webkit2png
@@ -418,6 +418,9 @@ Examples:
 
     # Hide the dock icon (needs to run before NSApplication.sharedApplication)
     AppKit.NSBundle.mainBundle().infoDictionary()['LSBackgroundOnly'] = '1'
+    
+    # Allow loading HTTP pages
+    AppKit.NSBundle.mainBundle().infoDictionary()['NSAppTransportSecurity'] = dict(NSAllowsArbitraryLoads = True)
 
     app = AppKit.NSApplication.sharedApplication()
 


### PR DESCRIPTION
This sets NSAllowsArbitraryLoads to true in order to allow all (non-SSL) HTTP requests.